### PR TITLE
🐛 Arreglar error de enlaces: vaciar lista

### DIFF
--- a/src/componentes/Ficha/Ficha.astro
+++ b/src/componentes/Ficha/Ficha.astro
@@ -184,6 +184,7 @@ const secciones = [
 
     // Llenar enlaces, si tiene
     if (datos.enlaces && datos.enlaces.length) {
+      seccionEnlaces.limpiar();
       seccionEnlaces.mostrar();
 
       datos.enlaces.forEach((elemento) => {


### PR DESCRIPTION
 Arreglar error de enlaces: vaciar lista antes de armar la nueva ficha.